### PR TITLE
use image_url for lookup to allow setting a default img to be displayed (404 by default)

### DIFF
--- a/src/Gravatar.php
+++ b/src/Gravatar.php
@@ -9,23 +9,21 @@ use GuzzleHttp\Exception\RequestException;
 
 class Gravatar
 {
-    private const PROFILE_URL = 'https://www.gravatar.com/%s.json';
-    private const IMAGE_URL   = 'https://www.gravatar.com/avatar/%s.jpg%s';
+    private const IMAGE_URL   = 'https://www.gravatar.com/avatar/%s.jpg?d=%s%s';
 
     private $http;
+    private $defaultImg;
 
-    public function __construct(Client $http)
+    public function __construct(Client $http, string $defaultImg = '404')
     {
         $this->http = $http;
+        $this->defaultImg = $defaultImg;
     }
 
     public function exists(string $email, bool $hashed = false): bool
     {
         try {
-            if($hashed){
-                return $this->http->head(sprintf(self::PROFILE_URL, $email))->getStatusCode() === 200;
-            }
-            return $this->http->head(sprintf(self::PROFILE_URL, $this->emailHash($email)))->getStatusCode() === 200;
+          return $this->http->head($this->imageUrl($email, 1, $hashed))->getStatusCode() === 200;
         } catch(RequestException $e) {
             return false;
         }
@@ -35,14 +33,14 @@ class Gravatar
     {
         $_size = '';
         if (!is_null($size)) {
-            $_size = '?size=' . $size;
+            $_size = '&size=' . $size;
         }
 
         if($hashed){
-            return sprintf(self::IMAGE_URL, $email, $_size);
+            return sprintf(self::IMAGE_URL, $email, $this->defaultImg, $_size);
         }
-                                         
-        return sprintf(self::IMAGE_URL, $this->emailHash($email), $_size);
+
+        return sprintf(self::IMAGE_URL, $this->emailHash($email), $this->defaultImg, $_size);
     }
 
     private function emailHash(string $email): string


### PR DESCRIPTION
to avoid showing the default gravatar img in case someone deleted their picture